### PR TITLE
Only wait for results when the api demands to, instead of always

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "golang.go",
+    "ms-python.python",
+    "ms-toolsai.jupyter",
+    "ms-python.vscode-pylance"
+  ]
+}

--- a/fetch/gh/internal/api/api.go
+++ b/fetch/gh/internal/api/api.go
@@ -28,9 +28,9 @@ func runWithRetry(m *retryManager, args []string) bytes.Buffer {
 	}
 	retry, backoff := m.retryAfter(err)
 	if !retry {
-		log.Fatal(err)
+		log.Fatalf("FAILED: %s. No retry supported with this error.", err)
 	}
-	log.Printf("WARNING: gh invocation failed with %s. Retrying after %s", err, backoff)
+	log.Printf("WARNING: %s. Retrying after %s", err, backoff)
 	time.Sleep(backoff)
 	return runWithRetry(m, args)
 }

--- a/fetch/gh/internal/api/retry.go
+++ b/fetch/gh/internal/api/retry.go
@@ -1,13 +1,16 @@
 package api
 
 import (
+	"log"
 	"strings"
 	"time"
+
+	"github.com/cli/go-gh"
 )
 
 type retryManager struct {
-	count5XX      int
-	countThrottle int
+	count5XX                        int
+	countSecondaryRateLimitExceeded int
 }
 
 func (m *retryManager) retryAfter(err error) (bool, time.Duration) {
@@ -20,25 +23,57 @@ func (m *retryManager) retryAfter(err error) (bool, time.Duration) {
 		return true, backoff
 	}
 
-	if isErrorThrottle(err) {
-		m.countThrottle++
-		backoff := time.Duration(m.countThrottle) * baseBackoffThrottle
+	// A user has exceeded their rate limit, more info: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
+	if isUserRateLimitExceeded(err) {
+		backoff := time.Duration(getUserRateLimitResetTime()-time.Now().Unix()) * time.Second
+		return true, backoff
+	}
+
+	// A specific API is called too often, more info: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits
+	if isSecondaryRateLimitExceeded(err) {
+		m.countSecondaryRateLimitExceeded++
+		// TODO: instead of an exponential backoff, we should use the `retry-after` response header
+		backoff := time.Duration(m.countSecondaryRateLimitExceeded) * baseBackoffSecondaryRateLimit
 		if backoff > maxBackoff {
 			return false, 0
 		}
 		return true, backoff
 	}
+
 	return false, 0
 }
 
 const baseBackoff5XX = 1 * time.Minute
-const baseBackoffThrottle = 10 * time.Minute
+const baseBackoffSecondaryRateLimit = 3 * time.Minute
 const maxBackoff = 25 * time.Minute
 
 func isError5XX(err error) bool {
 	return strings.Contains(err.Error(), "HTTP 500") || strings.Contains(err.Error(), "HTTP 502") || strings.Contains(err.Error(), "HTTP 503")
 }
 
-func isErrorThrottle(err error) bool {
-	return strings.Contains(err.Error(), "API rate limit exceeded")
+func isUserRateLimitExceeded(err error) bool {
+	return strings.Contains(err.Error(), "API rate limit exceeded for user ID")
+}
+
+func getUserRateLimitResetTime() int64 {
+	client, err := gh.RESTClient(nil)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	response := &struct {
+		Resources struct {
+			Core struct {
+				Reset int64
+			}
+		}
+	}{}
+
+	client.Get("rate_limit", response)
+	return response.Resources.Core.Reset
+}
+
+func isSecondaryRateLimitExceeded(err error) bool {
+	return strings.Contains(err.Error(), "You have exceeded a secondary rate limit")
 }

--- a/fetch/gh/internal/workerpool/batched.go
+++ b/fetch/gh/internal/workerpool/batched.go
@@ -2,7 +2,6 @@ package workerpool
 
 import (
 	"log"
-	"time"
 )
 
 func RunBatched(poolSize int, batchSize int, actions []func()) {
@@ -17,7 +16,6 @@ func RunBatched(poolSize int, batchSize int, actions []func()) {
 			j = len(actions)
 		}
 		Run(poolSize, actions[i:j])
-		log.Printf("Processed %d of %d actions. Waiting for %s before next batch.", j, len(actions), batchWaitTime)
-		time.Sleep(batchWaitTime)
+		log.Printf("Processed %d of %d actions.", j, len(actions))
 	}
 }

--- a/fetch/gh/internal/workerpool/run.go
+++ b/fetch/gh/internal/workerpool/run.go
@@ -2,7 +2,6 @@ package workerpool
 
 import (
 	"sync"
-	"time"
 )
 
 func Run(poolSize int, actions []func()) {
@@ -40,5 +39,3 @@ type poolItem struct {
 	Action func()
 	Done   bool
 }
-
-const batchWaitTime = 5 * time.Minute


### PR DESCRIPTION
## What
* Instead of waiting for 5minutes on every batch request, use the retry manager to perform waits only when the api says rate limits have been reached
* For user rate retreive this from a `rate_limit` rest request instead of an arbitrary wait
* Add some vscode extension recommendations

## Why
Reduce time to run significantly (reduced a 7hr run to 1hr 13min)

## How Tested
"Worked on my machine"
![image](https://user-images.githubusercontent.com/2684369/221047734-60748570-2b0c-4827-a9fc-aeeab63e5cdc.png)
